### PR TITLE
Add more file extensions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,16 +1,1 @@
 BasedOnStyle: LLVM
-AlignAfterOpenBracket: false
-AllowShortFunctionsOnASingleLine: None
-AlwaysBreakBeforeMultilineStrings: false
-BreakBeforeBinaryOperators: All
-BreakBeforeBraces: Linux
-ColumnLimit: 0
-ExperimentalAutoDetectBinPacking: true
-IndentCaseLabels: true
-IndentWidth: 4
-MaxEmptyLinesToKeep: 2
-ObjCBlockIndentWidth: 4
-ObjCSpaceAfterProperty: true
-ObjCSpaceBeforeProtocolList: false
-SpaceAfterCStyleCast: true
-TabWidth: 4

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,16 @@
+BasedOnStyle: LLVM
+AlignAfterOpenBracket: false
+AllowShortFunctionsOnASingleLine: None
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Linux
+ColumnLimit: 0
+ExperimentalAutoDetectBinPacking: true
+IndentCaseLabels: true
+IndentWidth: 4
+MaxEmptyLinesToKeep: 2
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+SpaceAfterCStyleCast: true
+TabWidth: 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ branches:
 addons:
   apt:
     packages: [
-      clang-format-3.6
+      clang-format-3.8
     ]
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 [![Build Status](https://travis-ci.org/flix-tech/danger-code_style_validation.svg?branch=master)](https://travis-ci.org/flix-tech/danger-code_style_validation)
 
-This plugin looks for code style violations for added lines and suggests patches.
-
-It uses 'clang-format' and only checks `.h`, `.m` and `.mm` files
+This plugin uses 'clang-format' to look for code style violations in added
+lines on the current MR / PR, and offers inline patches.
+By default only Objective-C files, with extensions `.h`, `.m`, `.mm` and
+`.C`, are checked.
 
 ![Example](/doc/images/example.png)
 
@@ -22,6 +23,12 @@ Inside your `Dangerfile` :
 
 ```ruby
 code_style_validation.check
+```
+
+To check files with extensions other than the default ones:
+
+```ruby
+code_style_validation.check file_extensions: ['.hpp', '.cpp']
 ```
 
 To ignore specific paths, use `ignore_file_patterns` :

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 This plugin uses 'clang-format' to look for code style violations in added
 lines on the current MR / PR, and offers inline patches.
-By default only Objective-C files, with extensions `.h`, `.m`, `.mm` and
-`.C`, are checked.
+By default only Objective-C files, with extensions `.h`, `.m`, and `.mm` are
+checked.
 
 ![Example](/doc/images/example.png)
 

--- a/lib/code_style_validation/plugin.rb
+++ b/lib/code_style_validation/plugin.rb
@@ -3,7 +3,8 @@ module Danger
   # added lines on the current MR / PR,
   # and offers inline patches.
   #
-  # It uses 'clang-format' and only checks ".h", ".m" and ".mm" files
+  # It uses 'clang-format' and only checks ".h", ".m", ".mm", ".hpp", ".hh",
+  # ".cxx", ".cc" and ".cpp" files
   #
   # @example Ensure that added lines does not violate code style
   #
@@ -43,7 +44,7 @@ module Danger
 
       return if message.empty?
       fail VIOLATION_ERROR_MESSAGE
-      markdown '### Code Style Check (`.h`, `.m` and `.mm`)'
+      markdown '### Code Style Check'
       markdown '---'
       markdown message
     end
@@ -69,7 +70,7 @@ module Danger
 
         file_name = filename_line.split('+++ b/').last.chomp
 
-        unless file_name.end_with?('.m', '.h', '.mm')
+        unless file_name.end_with?('.m', '.h', '.mm', '.hpp', '.hh', '.cxx', '.cc', '.cpp')
           next
         end
 
@@ -130,7 +131,14 @@ module Danger
     def resolve_changes(changes)
       # Parse all patches from diff string
 
-      markup_message = ''
+      markup_message = 'Code style violations detected in the following files:' + "\n"
+      changes.each do |file_name, changed_lines|
+	markup_message += '* `' + file_name + "`\n\n"
+      end
+
+      markup_message += 'Execute one of the following actions and commit again:' + "\n"
+      markup_message += '1. Run `clang-format` on the offending files' + "\n"
+      markup_message += '2. Apply the suggested patches with `git apply patch`.' + "\n"
 
       # patches.each do |patch|
       changes.each do |file_name, changed_lines|

--- a/lib/code_style_validation/plugin.rb
+++ b/lib/code_style_validation/plugin.rb
@@ -174,8 +174,8 @@ module Danger
 	# 1. Name of offending files
 	# 2. Suggested patches, in Markdown format
         unless diff.empty?
-	  offending_files = [file_name]
-	  patches = [generate_patch(file_name, diff)]
+	  offending_files.push(file_name)
+	  patches.push(generate_patch(file_name, diff))
         end
       end
 

--- a/lib/code_style_validation/plugin.rb
+++ b/lib/code_style_validation/plugin.rb
@@ -56,7 +56,7 @@ module Danger
         message += 'Execute one of the following actions and commit again:' + "\n"
         message += '1. Run `clang-format` on the offending files' + "\n"
         message += '2. Apply the suggested patches with `git apply patch`.' + "\n\n"
-        message += patches.join(' ')
+        message += patches.join("\n")
       end
 
       return if message.empty?

--- a/lib/code_style_validation/plugin.rb
+++ b/lib/code_style_validation/plugin.rb
@@ -1,9 +1,9 @@
 module Danger
   # This plugin uses 'clang-format' to look for code style violations in added
   # lines on the current MR / PR, and offers inline patches.
-  # By default only Objective-C files, with extensions ".h", ".m", ".mm" and
-  # ".C", are checked.
-  # 
+  # By default only Objective-C files, with extensions ".h", ".m", and ".mm"
+  # are checked.
+  #
   # @example Ensure that changes do not violate code style in Objective-C files
   #
   #          code_style_validation.check
@@ -21,13 +21,13 @@ module Danger
   #
   class DangerCodeStyleValidation < Plugin
     VIOLATION_ERROR_MESSAGE = 'Code style violations detected.'.freeze
-    
+
     # Validates the code style of changed & added files using clang-format.
     # Generates Markdown message with respective patches.
     #
     # @return [void]
     def check(config = {})
-      defaults = {file_extensions: ['.h', '.m', '.mm', '.C'], ignore_file_patterns: []}
+      defaults = {file_extensions: ['.h', '.m', '.mm'], ignore_file_patterns: []}
       config = defaults.merge(config)
       file_extensions = [*config[:file_extensions]]
       ignore_file_patterns = [*config[:ignore_file_patterns]]
@@ -49,15 +49,15 @@ module Danger
 
       message = ''
       unless offending_files.empty?
-        message = 'Code style violations detected in the following files:' + "\n"  
-	offending_files.each do |file_name|
-	  message += '* `' + file_name + "`\n\n"
-        end	
+        message = 'Code style violations detected in the following files:' + "\n"
+        offending_files.each do |file_name|
+          message += '* `' + file_name + "`\n\n"
+        end
         message += 'Execute one of the following actions and commit again:' + "\n"
         message += '1. Run `clang-format` on the offending files' + "\n"
         message += '2. Apply the suggested patches with `git apply patch`.' + "\n\n"
         message += patches.join(' ')
-      end 
+      end
 
       return if message.empty?
       fail VIOLATION_ERROR_MESSAGE
@@ -175,12 +175,12 @@ module Danger
         formatted_temp_file.close
         formatted_temp_file.unlink
 
-	# generate arrays with:
-	# 1. Name of offending files
-	# 2. Suggested patches, in Markdown format
+        # generate arrays with:
+        # 1. Name of offending files
+        # 2. Suggested patches, in Markdown format
         unless diff.empty?
-	  offending_files.push(file_name)
-	  patches.push(generate_patch(file_name, diff))
+          offending_files.push(file_name)
+          patches.push(generate_patch(file_name, diff))
         end
       end
 

--- a/spec/code_style_validation_spec.rb
+++ b/spec/code_style_validation_spec.rb
@@ -14,11 +14,13 @@ module Danger
 
       it 'Reports code style violation as error' do
         diff = File.read('spec/fixtures/violated_diff.diff')
+        expected_message = File.read('spec/fixtures/violated_diff_message.md')
 
         @my_plugin.github.stub(:pr_diff).and_return diff
         @my_plugin.check file_extensions: ['.h', '.m', '.mm', '.C', '.cpp']
 
         expect(@dangerfile.status_report[:errors]).to eq([DangerCodeStyleValidation::VIOLATION_ERROR_MESSAGE])
+        expect(@dangerfile.status_report[:markdowns].map(&:message).join("\n")).to eq(expected_message)
       end
 
       it 'Does not report error when extension is excluded' do

--- a/spec/code_style_validation_spec.rb
+++ b/spec/code_style_validation_spec.rb
@@ -21,6 +21,15 @@ module Danger
         expect(@dangerfile.status_report[:errors]).to eq([DangerCodeStyleValidation::VIOLATION_ERROR_MESSAGE])
       end
 
+      it 'Does not report error when extension is excluded' do
+        diff = File.read('spec/fixtures/violated_diff.diff')
+
+        @my_plugin.github.stub(:pr_diff).and_return diff
+        @my_plugin.check file_extensions: ['.h', '.c']
+
+        expect(@dangerfile.status_report[:errors]).to eq([])
+      end
+
       it 'Does not report error when code not violated' do
         diff = File.read('spec/fixtures/innocent_diff.diff')
 
@@ -52,7 +61,8 @@ module Danger
         diff = File.read('spec/fixtures/violated_diff.diff')
 
         @my_plugin.github.stub(:pr_diff).and_return diff
-        @my_plugin.check ignore_file_patterns: [%r{^spec/}]
+        @my_plugin.check file_extensions: ['.h', '.m'],
+                         ignore_file_patterns: [%r{^spec/}]
 
         expect(@dangerfile.status_report[:errors]).to eq([])
       end
@@ -64,6 +74,15 @@ module Danger
         @my_plugin.check ignore_file_patterns: %r{^spec/}
 
         expect(@dangerfile.status_report[:errors]).to eq([])
+      end
+
+      it 'Allows single file extension instead of array' do
+        diff = File.read('spec/fixtures/violated_diff.diff')
+
+        @my_plugin.github.stub(:pr_diff).and_return diff
+        @my_plugin.check file_extensions: '.m'
+
+        expect(@dangerfile.status_report[:errors]).to eq([DangerCodeStyleValidation::VIOLATION_ERROR_MESSAGE])
       end
     end
   end

--- a/spec/code_style_validation_spec.rb
+++ b/spec/code_style_validation_spec.rb
@@ -16,7 +16,7 @@ module Danger
         diff = File.read('spec/fixtures/violated_diff.diff')
 
         @my_plugin.github.stub(:pr_diff).and_return diff
-        @my_plugin.check
+        @my_plugin.check file_extensions: ['.h', '.m', '.mm', '.C', '.cpp']
 
         expect(@dangerfile.status_report[:errors]).to eq([DangerCodeStyleValidation::VIOLATION_ERROR_MESSAGE])
       end

--- a/spec/code_style_validation_spec.rb
+++ b/spec/code_style_validation_spec.rb
@@ -16,8 +16,8 @@ module Danger
         diff = File.read('spec/fixtures/violated_diff.diff')
         expected_message = File.read('spec/fixtures/violated_diff_message.md')
 
-        @my_plugin.github.stub(:pr_diff).and_return diff
-        @my_plugin.check file_extensions: ['.h', '.m', '.mm', '.C', '.cpp']
+        allow(@my_plugin.github).to receive(:pr_diff).and_return diff
+        @my_plugin.check file_extensions: ['.h', '.m', '.mm', '.cpp']
 
         expect(@dangerfile.status_report[:errors]).to eq([DangerCodeStyleValidation::VIOLATION_ERROR_MESSAGE])
         expect(@dangerfile.status_report[:markdowns].map(&:message).join("\n")).to eq(expected_message)
@@ -26,7 +26,7 @@ module Danger
       it 'Does not report error when extension is excluded' do
         diff = File.read('spec/fixtures/violated_diff.diff')
 
-        @my_plugin.github.stub(:pr_diff).and_return diff
+        allow(@my_plugin.github).to receive(:pr_diff).and_return diff
         @my_plugin.check file_extensions: ['.h', '.c']
 
         expect(@dangerfile.status_report[:errors]).to eq([])
@@ -35,7 +35,7 @@ module Danger
       it 'Does not report error when code not violated' do
         diff = File.read('spec/fixtures/innocent_diff.diff')
 
-        @my_plugin.github.stub(:pr_diff).and_return diff
+        allow(@my_plugin.github).to receive(:pr_diff).and_return diff
         @my_plugin.check
 
         expect(@dangerfile.status_report[:errors]).to eq([])
@@ -44,7 +44,7 @@ module Danger
       it 'Does not report error for different extension types of files' do
         diff = File.read('spec/fixtures/ruby_diff.diff')
 
-        @my_plugin.github.stub(:pr_diff).and_return diff
+        allow(@my_plugin.github).to receive(:pr_diff).and_return diff
         @my_plugin.check
 
         expect(@dangerfile.status_report[:errors]).to eq([])
@@ -53,7 +53,7 @@ module Danger
       it 'Does not report unexpected errors when there are only removals in the diff' do
         diff = File.read('spec/fixtures/red_diff.diff')
 
-        @my_plugin.github.stub(:pr_diff).and_return diff
+        allow(@my_plugin.github).to receive(:pr_diff).and_return diff
         @my_plugin.check
 
         expect(@dangerfile.status_report[:errors]).to eq([])
@@ -62,7 +62,7 @@ module Danger
       it 'Ignores files matching ignored patterns' do
         diff = File.read('spec/fixtures/violated_diff.diff')
 
-        @my_plugin.github.stub(:pr_diff).and_return diff
+        allow(@my_plugin.github).to receive(:pr_diff).and_return diff
         @my_plugin.check file_extensions: ['.h', '.m'],
                          ignore_file_patterns: [%r{^spec/}]
 
@@ -72,7 +72,7 @@ module Danger
       it 'Allows single pattern instead of array' do
         diff = File.read('spec/fixtures/violated_diff.diff')
 
-        @my_plugin.github.stub(:pr_diff).and_return diff
+        allow(@my_plugin.github).to receive(:pr_diff).and_return diff
         @my_plugin.check ignore_file_patterns: %r{^spec/}
 
         expect(@dangerfile.status_report[:errors]).to eq([])
@@ -81,7 +81,7 @@ module Danger
       it 'Allows single file extension instead of array' do
         diff = File.read('spec/fixtures/violated_diff.diff')
 
-        @my_plugin.github.stub(:pr_diff).and_return diff
+        allow(@my_plugin.github).to receive(:pr_diff).and_return diff
         @my_plugin.check file_extensions: '.m'
 
         expect(@dangerfile.status_report[:errors]).to eq([DangerCodeStyleValidation::VIOLATION_ERROR_MESSAGE])

--- a/spec/fixtures/violated_diff_message.md
+++ b/spec/fixtures/violated_diff_message.md
@@ -1,0 +1,30 @@
+### Code Style Check
+---
+Code style violations detected in the following files:
+* `spec/fixtures/BadViewController.m`
+
+Execute one of the following actions and commit again:
+1. Run `clang-format` on the offending files
+2. Apply the suggested patches with `git apply patch`.
+
+#### spec/fixtures/BadViewController.m
+```diff 
+--- spec/fixtures/BadViewController.m
++++ spec/fixtures/BadViewController.m
+@@ -1,9 +1,11 @@
+-@interface ViewController (  ) @end
++@interface ViewController ()
++@end
+ 
+ @implementation ViewController
+--(void ) viewDidLoad {
++- (void)viewDidLoad
++{
+     [super viewDidLoad];
+-    NSLog(  @"perfect change!")   ;
++    NSLog(@"perfect change!");
+ }
+ 
+ @end
+
+``` 

--- a/spec/fixtures/violated_diff_message.md
+++ b/spec/fixtures/violated_diff_message.md
@@ -11,18 +11,18 @@ Execute one of the following actions and commit again:
 ```diff 
 --- spec/fixtures/BadViewController.m
 +++ spec/fixtures/BadViewController.m
-@@ -1,9 +1,11 @@
+@@ -1,9 +1,10 @@
 -@interface ViewController (  ) @end
 +@interface ViewController ()
 +@end
  
  @implementation ViewController
 --(void ) viewDidLoad {
-+- (void)viewDidLoad
-+{
-     [super viewDidLoad];
+-    [super viewDidLoad];
 -    NSLog(  @"perfect change!")   ;
-+    NSLog(@"perfect change!");
++- (void)viewDidLoad {
++  [super viewDidLoad];
++  NSLog(@"perfect change!");
  }
  
  @end


### PR DESCRIPTION
I am not a Ruby expert, but I've managed to make the following changes:
- [x] The plugin now also checks files with extensions `.hpp`, `.hh`, `.cxx`, `.cc`, `.cpp`, hence addressing #2  
- [x] The error message is more informative. It first lists the offending files, then suggests appropriate actions and eventually prints the patches to apply.
- [x] Generation of the more informative error message is now done differently. 
- [x] Pass the list of extensions to check to the plugin, instead of hardcoding the valid extensions. Default behavior only checks Objective-C extensions (`.h`, `.m`, `.mm`)

You can see the plugin in action for this example repository: https://github.com/PCMSolver/danger-cpp-example/pull/3

~### Questions/Ideas~

~- [ ] I haven't added tests, because I don't know how to.~
~- [ ]Generating the more informative error message requires iterating twice over the `changes` array.~