### PR TITLE
Pass executable for code style validator

### DIFF
--- a/lib/code_style_validation/plugin.rb
+++ b/lib/code_style_validation/plugin.rb
@@ -27,8 +27,9 @@ module Danger
     #
     # @return [void]
     def check(config = {})
-      defaults = {file_extensions: ['.h', '.m', '.mm'], ignore_file_patterns: []}
+      defaults = {validator: ['clang-format'], file_extensions: ['.h', '.m', '.mm'], ignore_file_patterns: []}
       config = defaults.merge(config)
+      validator = *config[:validator]
       file_extensions = [*config[:file_extensions]]
       ignore_file_patterns = [*config[:ignore_file_patterns]]
 
@@ -45,7 +46,7 @@ module Danger
       end
 
       changes = get_changes(diff, file_extensions, ignore_file_patterns)
-      offending_files, patches = resolve_changes(changes)
+      offending_files, patches = resolve_changes(validator, changes)
 
       message = ''
       unless offending_files.empty?
@@ -145,7 +146,7 @@ module Danger
       markup_patch
     end
 
-    def resolve_changes(changes)
+    def resolve_changes(validator, changes)
       # Parse all patches from diff string
 
       offending_files = []
@@ -159,7 +160,7 @@ module Danger
         end
 
         changed_lines_command = changed_lines_command_array.join(' ')
-        format_command_array = ['clang-format', changed_lines_command, file_name]
+        format_command_array = [validator, changed_lines_command, file_name]
 
         # clang-format command for formatting JUST changed lines
         formatted = `#{format_command_array.join(' ')}`

--- a/spec/code_style_validation_spec.rb
+++ b/spec/code_style_validation_spec.rb
@@ -27,7 +27,8 @@ module Danger
         diff = File.read('spec/fixtures/violated_diff.diff')
 
         allow(@my_plugin.github).to receive(:pr_diff).and_return diff
-        @my_plugin.check file_extensions: ['.h', '.c']
+        @my_plugin.check validator: 'clang-format',
+                         file_extensions: ['.h', '.c']
 
         expect(@dangerfile.status_report[:errors]).to eq([])
       end


### PR DESCRIPTION
I use `clang-format-3.9`. Using the Trusty images on Travis, ships version 3.5 as `clang-format` which generated some false positives for my project. I have added an additional `validator` parameter to prevent this. This could be a stepping stone to provide support for checkers _othen than_ `clang-format` **and** for languages _other than_ those covered by `clang-format`. I have other projects where I would like to use [yapf](https://github.com/google/yapf) for Python, for example. I aim at filing a PR later on for these additions.