### PR TITLE
Code style validation for Python using YAPF

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Nikolay Kasyanov <nikolay.kasyanov@flixbus.com> <nikolaykasyanov@users.noreply.github.com>
+Ersen Tekin <ersen.tekin@flixbus.com>
+Roberto Di Remigio <roberto.diremigio@gmail.com> <robertodr@users.noreply.github.com>

--- a/spec/code_style_validation_spec.rb
+++ b/spec/code_style_validation_spec.rb
@@ -33,6 +33,16 @@ module Danger
         expect(@dangerfile.status_report[:errors]).to eq([])
       end
 
+      it 'Accepts a validator other than clang-format' do
+        diff = File.read('spec/fixtures/violated_diff.diff')
+
+        allow(@my_plugin.github).to receive(:pr_diff).and_return diff
+        @my_plugin.check validator: 'yapf',
+                         file_extensions: ['.py']
+
+        expect(@dangerfile.status_report[:errors]).to eq([])
+      end
+
       it 'Does not report error when code not violated' do
         diff = File.read('spec/fixtures/innocent_diff.diff')
 


### PR DESCRIPTION
This PR enables the use of YAPF for Python code style validation. Have a look [here](https://github.com/PCMSolver/danger-python-example/pull/1) for an example.

Some questions:
1. The format for passing lines to reformat is slightly different between `clang-format` and `yapf`:
    - The former can be invoked with `clang-format -lines=start:end`
    - The latter can be invoked with `yapf --lines=start-end`

I have inserted a check on the `validator` name in `resolve_changes` to get the correct argument set up for the actual call to the validator. This is not really clean, @nikolaykasyanov do you have suggestions on how to possibly improve on this? 
2. I have put a test "Accepts a validator other than clang-format". Is that enough?

